### PR TITLE
Fix jquery dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
         "jquery"
     ],
     "dependencies" : {
-        "jQuery"   :  "1.7.4"
+        "jquery"   :  "1.7.4"
     },
     "license": "MIT"
 }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
         "jquery"
     ],
     "dependencies" : {
-        "jquery"   :  "1.7.4"
+        "jquery"   :  "1.7.2"
     },
     "license": "MIT"
 }


### PR DESCRIPTION
Fixing this:
```
npm WARN deprecated jQuery@1.7.4: This is deprecated. Please use 'jquery' (all lowercase).
```