### PR TITLE
Fix jQuery version in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "jquery"
   ],
   "dependencies": {
-    "jquery": "1.7.2"
+    "jquery": ">=1.7.2 <3.0.0"
   },
   "license": "MIT",
   "devDependencies": {


### PR DESCRIPTION
Updated "jquery" in package.json to be more flexible, allowing a version range between 1.7.2 and latest 2.x. This is needed because `yarn install` errors out otherwise. Also, `npm install` produces this warning: "…Versions of the jquery npm package older than 1.9.0 are patched versions that don't work in web browsers"