### PR TITLE
Added option for navigation container

### DIFF
--- a/js/jquery.responsiveTabs.js
+++ b/js/jquery.responsiveTabs.js
@@ -17,6 +17,7 @@
         scrollToAccordionOnLoad: true,
         scrollToAccordionOffset: 0,
         accordionTabElement: '<div></div>',
+        navigationContainer: '',
         click: function(){},
         activate: function(){},
         deactivate: function(){},
@@ -153,7 +154,7 @@
      */
     ResponsiveTabs.prototype._loadElements = function() {
         var _this = this;
-        var $ul = this.$element.children('ul:first');
+        var $ul = (_this.options.navigationContainer === '') ? this.$element.children('ul:first') : this.$element.find(_this.options.navigationContainer).children('ul:first');
         var tabs = [];
         var id = 0;
 


### PR DESCRIPTION
Added an option to reference a container that wraps around the navigation ul.

• New option: navigationContainer (default is empty)
• Can be a class or an element, but has to be inside the tab element.
• If container is set, this is used as the $ul variable instead.

Keep up the great work! It's still the best responsive tab plugin! :)